### PR TITLE
Fix bug

### DIFF
--- a/ukam_os_builder/os_builder/pipeline_factory.py
+++ b/ukam_os_builder/os_builder/pipeline_factory.py
@@ -134,7 +134,9 @@ def run_pipeline(
         step_runners["download"](settings, force, True)
         return
 
-    run_order = valid_steps if step == "all" else [step]
+    run_order = (
+        [pipeline_step.name for pipeline_step in definition.steps] if step == "all" else [step]
+    )
     for step_name in run_order:
         if force:
             _clean_outputs_for_step(


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/robin.linacre/Documents/data_linking/prepare_os_for_address_matching/ukam_os_builder/cli.py", line 127, in main
    run_from_config(
    ~~~~~~~~~~~~~~~^
        config_path=config_path,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    ...<17 lines>...
        parquet_compression_level=args.parquet_compression_level,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/robin.linacre/Documents/data_linking/prepare_os_for_address_matching/ukam_os_builder/api/api.py", line 354, in run_from_config
    run_pipeline(step=step, settings=settings, force=overwrite_effective, list_only=list_only)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/robin.linacre/Documents/data_linking/prepare_os_for_address_matching/ukam_os_builder/pipeline.py", line 107, in run
    run_pipeline(
    ~~~~~~~~~~~~^
        definition=definition,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        logger=logger,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/Users/robin.linacre/Documents/data_linking/prepare_os_for_address_matching/ukam_os_builder/os_builder/pipeline_factory.py", line 151, in run_pipeline
    if step == "all" and step_name != run_order[-1]:
                                      ~~~~~~~~~^^^^
TypeError: 'set' object is not subscriptable
```