### PR TITLE
Make NGD and ABP address feature exclusions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ Welsh language variants are extracted where available and appear as separate row
 By default, all listed NGD feature types are processed. To exclude feature types, set
 `processing.ngd_excluded_stems` in `config.yaml` or pass `--ngd-excluded-stems`.
 Valid values are `builtaddress`, `prebuildaddress`, `historicaddress`,
-`nonaddressableobject`, `royalmailaddress`, and `*_altadd`. Core feature names match only
-their core files; use `*_altadd` to exclude alternate-address files.
+`nonaddressableobject`, and `royalmailaddress`. When a feature stem is excluded, its
+matching alternate-address file is excluded too; for example, `builtaddress` excludes
+both `add_gb_builtaddress` and `add_gb_builtaddress_altadd`.
 
 ABP LPI logical statuses are also all processed by default, including Historic
 (`logical_status=8`). To exclude ABP statuses, set

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ create_config_and_env(
   source="ngd",
   package_id="16331",
   version_id="104444",
+  ngd_excluded_stems=[],
+  abp_excluded_logical_statuses=[],
 )
 
 run_from_config(config_path="config.yaml", step="all")
@@ -132,7 +134,7 @@ The tool derives all other directories automatically under `work_dir`.
 | Command | Purpose | Key options |
 |---|---|---|
 | `ukam-os-setup` | Create or update pipeline config interactively | `--config-out`, `--env-out`, `--overwrite-env`, `--non-interactive`, `--source`, `--package-id`, `--version-id` |
-| `ukam-os-build` | Run pipeline stages (`download`, `extract`, `split`, `flatfile`, `all`) | `--config`, `--source`, `--env-file`, `--step`, `--overwrite`, `--list-only`, `--package-id`, `--version-id`, `--work-dir`, `--downloads-dir`, `--extracted-dir`, `--output-dir`, `--num-chunks`, `--duckdb-memory-limit`, `--parquet-compression`, `--parquet-compression-level`, `--verbose` |
+| `ukam-os-build` | Run pipeline stages (`download`, `extract`, `split`, `flatfile`, `all`) | `--config`, `--source`, `--env-file`, `--step`, `--overwrite`, `--list-only`, `--package-id`, `--version-id`, `--work-dir`, `--downloads-dir`, `--extracted-dir`, `--output-dir`, `--num-chunks`, `--duckdb-memory-limit`, `--parquet-compression`, `--parquet-compression-level`, `--ngd-excluded-stems`, `--abp-excluded-logical-statuses`, `--verbose` |
 
 ### Command notes
 
@@ -250,6 +252,18 @@ The pipeline processes these NGD address feature types:
 
 Welsh language variants are extracted where available and appear as separate rows in the output.
 
+By default, all listed NGD feature types are processed. To exclude feature types, set
+`processing.ngd_excluded_stems` in `config.yaml` or pass `--ngd-excluded-stems`.
+Valid values are `builtaddress`, `prebuildaddress`, `historicaddress`,
+`nonaddressableobject`, `royalmailaddress`, and `*_altadd`. Core feature names match only
+their core files; use `*_altadd` to exclude alternate-address files.
+
+ABP LPI logical statuses are also all processed by default, including Historic
+(`logical_status=8`). To exclude ABP statuses, set
+`processing.abp_excluded_logical_statuses` or pass `--abp-excluded-logical-statuses`.
+Valid values are `1` (approved), `3` (alternative), `6` (provisional), and `8`
+(historic).
+
 ## Deduplication
 
 When the same UPRN and address combination appears in multiple sources, records are deduplicated using these internal priority rules:
@@ -320,6 +334,8 @@ processing:
   parquet_compression: zstd
   parquet_compression_level: 9
   num_chunks: 20
+  ngd_excluded_stems: []
+  abp_excluded_logical_statuses: []
   # duckdb_memory_limit: "8GB"
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ create_config_and_env(
   source="ngd",
   package_id="16331",
   version_id="104444",
-  ngd_excluded_stems=[],
-  abp_excluded_logical_statuses=[],
+  ngd_excluded_stems=["historicaddress"],
+  abp_excluded_logical_statuses=[8],
 )
 
 run_from_config(config_path="config.yaml", step="all")
@@ -252,18 +252,28 @@ The pipeline processes these NGD address feature types:
 
 Welsh language variants are extracted where available and appear as separate rows in the output.
 
-By default, all listed NGD feature types are processed. To exclude feature types, set
-`processing.ngd_excluded_stems` in `config.yaml` or pass `--ngd-excluded-stems`.
+By default, NGD Historic Address and ABP Historic LPI records are excluded. 
+Ordnance Survey experts advised that historic addresses can make address matching worse, 
+because many records are not comprehensive old-business history; they can include planning, 
+placeholder, or later replaced address variants that incorrectly match current addresses. 
+Labelled data checks also showed historic records causing incorrect matches. Historic
+records may still improve some use cases, but they should be used carefully because adding 
+them can fix some matches while degrading others. 
+For use cases that need older business or address history, old cuts of NGD BuiltAddress or 
+AddressBase may be more appropriate.
+
+To change NGD feature exclusions, set `processing.ngd_excluded_stems` in
+`config.yaml` or pass `--ngd-excluded-stems`.
 Valid values are `builtaddress`, `prebuildaddress`, `historicaddress`,
 `nonaddressableobject`, and `royalmailaddress`. When a feature stem is excluded, its
 matching alternate-address file is excluded too; for example, `builtaddress` excludes
-both `add_gb_builtaddress` and `add_gb_builtaddress_altadd`.
+both `add_gb_builtaddress` and `add_gb_builtaddress_altadd`. 
+To include NGD historic addresses, set `ngd_excluded_stems: []`.
 
-ABP LPI logical statuses are also all processed by default, including Historic
-(`logical_status=8`). To exclude ABP statuses, set
-`processing.abp_excluded_logical_statuses` or pass `--abp-excluded-logical-statuses`.
-Valid values are `1` (approved), `3` (alternative), `6` (provisional), and `8`
-(historic).
+To change ABP status exclusions, set `processing.abp_excluded_logical_statuses` 
+or pass `--abp-excluded-logical-statuses`.
+Valid values are `1` (approved), `3` (alternative), `6` (provisional), and `8` (historic). 
+To include ABP historical records, set `abp_excluded_logical_statuses: []`.
 
 ## Deduplication
 
@@ -335,8 +345,10 @@ processing:
   parquet_compression: zstd
   parquet_compression_level: 9
   num_chunks: 20
-  ngd_excluded_stems: []
-  abp_excluded_logical_statuses: []
+  ngd_excluded_stems:
+    - historicaddress
+  abp_excluded_logical_statuses:
+    - 8
   # duckdb_memory_limit: "8GB"
 ```
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,11 +44,15 @@ processing:
   num_chunks: 20
 
   # NGD feature stems to exclude from download, extract, and flatfile processing
+  # Historic addresses are excluded by default
   # Valid values: builtaddress, prebuildaddress, historicaddress,
   # nonaddressableobject, royalmailaddress
   # Matching alternate-address files are excluded with their feature stem.
-  ngd_excluded_stems: []
+  ngd_excluded_stems:
+    - historicaddress
 
   # ABP LPI logical statuses to exclude from flatfile processing
+  # Logical status 8 is excluded by default 
   # Valid values: 1 (approved), 3 (alternative), 6 (provisional), 8 (historic)
-  abp_excluded_logical_statuses: []
+  abp_excluded_logical_statuses:
+    - 8

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -42,3 +42,12 @@ processing:
   # Use higher values (e.g., 10) for lower memory usage on laptops
   # Output will be split into multiple parquet files, one per chunk
   num_chunks: 20
+
+  # NGD feature stems to exclude from download, extract, and flatfile processing
+  # Valid values: builtaddress, prebuildaddress, historicaddress,
+  # nonaddressableobject, royalmailaddress, "*_altadd"
+  ngd_excluded_stems: []
+
+  # ABP LPI logical statuses to exclude from flatfile processing
+  # Valid values: 1 (approved), 3 (alternative), 6 (provisional), 8 (historic)
+  abp_excluded_logical_statuses: []

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -45,7 +45,8 @@ processing:
 
   # NGD feature stems to exclude from download, extract, and flatfile processing
   # Valid values: builtaddress, prebuildaddress, historicaddress,
-  # nonaddressableobject, royalmailaddress, "*_altadd"
+  # nonaddressableobject, royalmailaddress
+  # Matching alternate-address files are excluded with their feature stem.
   ngd_excluded_stems: []
 
   # ABP LPI logical statuses to exclude from flatfile processing

--- a/tests/test_abp_exclusions.py
+++ b/tests/test_abp_exclusions.py
@@ -8,7 +8,7 @@ from ukam_os_builder.data_sources.abp.abp_exclusions import (
 )
 
 
-def test_abp_logical_statuses_include_historic_by_default() -> None:
+def test_abp_logical_statuses_include_historic_with_empty_exclusions() -> None:
     assert included_abp_logical_statuses([]) == [1, 3, 6, 8]
 
 

--- a/tests/test_abp_exclusions.py
+++ b/tests/test_abp_exclusions.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from ukam_os_builder.data_sources.abp.abp_exclusions import (
+    included_abp_logical_statuses,
+    parse_abp_excluded_logical_statuses,
+)
+
+
+def test_abp_logical_statuses_include_historic_by_default() -> None:
+    assert included_abp_logical_statuses([]) == [1, 3, 6, 8]
+
+
+def test_abp_logical_status_exclusions_are_configurable() -> None:
+    assert parse_abp_excluded_logical_statuses("8,3,8") == [8, 3]
+    assert included_abp_logical_statuses([8]) == [1, 3, 6]
+
+
+def test_abp_logical_status_exclusions_reject_unknown_status() -> None:
+    with pytest.raises(ValueError, match="invalid ABP excluded logical status"):
+        parse_abp_excluded_logical_statuses("2")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,10 +36,50 @@ def test_create_config_and_env_writes_expected_files(tmp_path: Path) -> None:
     assert 'package_id: "16331"' in config_text
     assert 'version_id: "104444"' in config_text
     assert "num_chunks: 20" in config_text
+    assert "ngd_excluded_stems: []" in config_text
+    assert "abp_excluded_logical_statuses: []" in config_text
 
     env_text = env_path.read_text()
     assert "OS_PROJECT_API_KEY=your_api_key_here" in env_text
     assert "OS_PROJECT_API_SECRET=your_api_secret_here" in env_text
+
+
+def test_create_config_and_env_writes_ngd_excluded_stems(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+
+    create_config_and_env(
+        config_out=config_path,
+        env_out=env_path,
+        source="ngd",
+        package_id="16331",
+        version_id="104444",
+        ngd_excluded_stems=["HistoricAddress", "*_ALTADD", "historicaddress"],
+    )
+
+    config_text = config_path.read_text()
+    assert "ngd_excluded_stems:" in config_text
+    assert "    - historicaddress" in config_text
+    assert '    - "*_altadd"' in config_text
+
+
+def test_create_config_and_env_writes_abp_excluded_logical_statuses(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    env_path = tmp_path / ".env"
+
+    create_config_and_env(
+        config_out=config_path,
+        env_out=env_path,
+        source="abp",
+        package_id="16331",
+        version_id="104444",
+        abp_excluded_logical_statuses=[8, 3, 8],
+    )
+
+    config_text = config_path.read_text()
+    assert "abp_excluded_logical_statuses:" in config_text
+    assert "    - 8" in config_text
+    assert "    - 3" in config_text
 
 
 def test_create_config_and_env_writes_supplied_api_credentials(tmp_path: Path) -> None:
@@ -108,6 +148,10 @@ def test_run_from_config_applies_overrides(
         calls["force"] = force
         calls["list_only"] = list_only
         calls["num_chunks"] = settings.processing.num_chunks
+        calls["ngd_excluded_stems"] = settings.processing.ngd_excluded_stems
+        calls["abp_excluded_logical_statuses"] = (
+            settings.processing.abp_excluded_logical_statuses
+        )
 
     monkeypatch.setattr("ukam_os_builder.api.api.get_package_version", fake_check_api)
     monkeypatch.setattr("ukam_os_builder.api.api.run_pipeline", fake_run_pipeline)
@@ -118,6 +162,8 @@ def test_run_from_config_applies_overrides(
         list_only=True,
         force=True,
         num_chunks=5,
+        ngd_excluded_stems="historicaddress,*_altadd",
+        abp_excluded_logical_statuses="8,3",
     )
 
     assert calls["checked_api"] is True
@@ -125,6 +171,8 @@ def test_run_from_config_applies_overrides(
     assert calls["force"] is True
     assert calls["list_only"] is True
     assert calls["num_chunks"] == 5
+    assert calls["ngd_excluded_stems"] == ["historicaddress", "*_altadd"]
+    assert calls["abp_excluded_logical_statuses"] == [8, 3]
 
 
 def test_run_from_config_accepts_api_key_secret_overrides(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,13 +54,13 @@ def test_create_config_and_env_writes_ngd_excluded_stems(tmp_path: Path) -> None
         source="ngd",
         package_id="16331",
         version_id="104444",
-        ngd_excluded_stems=["HistoricAddress", "*_ALTADD", "historicaddress"],
+        ngd_excluded_stems=["HistoricAddress", "prebuildaddress", "historicaddress"],
     )
 
     config_text = config_path.read_text()
     assert "ngd_excluded_stems:" in config_text
     assert "    - historicaddress" in config_text
-    assert '    - "*_altadd"' in config_text
+    assert "    - prebuildaddress" in config_text
 
 
 def test_create_config_and_env_writes_abp_excluded_logical_statuses(tmp_path: Path) -> None:
@@ -162,7 +162,7 @@ def test_run_from_config_applies_overrides(
         list_only=True,
         force=True,
         num_chunks=5,
-        ngd_excluded_stems="historicaddress,*_altadd",
+        ngd_excluded_stems="historicaddress,prebuildaddress",
         abp_excluded_logical_statuses="8,3",
     )
 
@@ -171,7 +171,7 @@ def test_run_from_config_applies_overrides(
     assert calls["force"] is True
     assert calls["list_only"] is True
     assert calls["num_chunks"] == 5
-    assert calls["ngd_excluded_stems"] == ["historicaddress", "*_altadd"]
+    assert calls["ngd_excluded_stems"] == ["historicaddress", "prebuildaddress"]
     assert calls["abp_excluded_logical_statuses"] == [8, 3]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,8 +36,10 @@ def test_create_config_and_env_writes_expected_files(tmp_path: Path) -> None:
     assert 'package_id: "16331"' in config_text
     assert 'version_id: "104444"' in config_text
     assert "num_chunks: 20" in config_text
-    assert "ngd_excluded_stems: []" in config_text
-    assert "abp_excluded_logical_statuses: []" in config_text
+    assert "ngd_excluded_stems:" in config_text
+    assert "    - historicaddress" in config_text
+    assert "abp_excluded_logical_statuses:" in config_text
+    assert "    - 8" in config_text
 
     env_text = env_path.read_text()
     assert "OS_PROJECT_API_KEY=your_api_key_here" in env_text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_build_cli_passes_api_credentials_to_run_from_config(monkeypatch) -> Non
             "--api-secret",
             "runtime-secret",
             "--ngd-excluded-stems",
-            "historicaddress,*_altadd",
+            "historicaddress,prebuildaddress",
             "--abp-excluded-logical-statuses",
             "8,3",
         ]
@@ -34,5 +34,5 @@ def test_build_cli_passes_api_credentials_to_run_from_config(monkeypatch) -> Non
     assert exit_code == 0
     assert captured["api_key"] == "runtime-key"
     assert captured["api_secret"] == "runtime-secret"
-    assert captured["ngd_excluded_stems"] == "historicaddress,*_altadd"
+    assert captured["ngd_excluded_stems"] == "historicaddress,prebuildaddress"
     assert captured["abp_excluded_logical_statuses"] == "8,3"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,9 +24,15 @@ def test_build_cli_passes_api_credentials_to_run_from_config(monkeypatch) -> Non
             "runtime-key",
             "--api-secret",
             "runtime-secret",
+            "--ngd-excluded-stems",
+            "historicaddress,*_altadd",
+            "--abp-excluded-logical-statuses",
+            "8,3",
         ]
     )
 
     assert exit_code == 0
     assert captured["api_key"] == "runtime-key"
     assert captured["api_secret"] == "runtime-secret"
+    assert captured["ngd_excluded_stems"] == "historicaddress,*_altadd"
+    assert captured["abp_excluded_logical_statuses"] == "8,3"

--- a/tests/test_extract_source_filtering.py
+++ b/tests/test_extract_source_filtering.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 from ukam_os_builder.os_builder.extract import (
     _filter_zips_for_source,
     _should_convert_csv_to_parquet,
 )
+from ukam_os_builder.os_builder.os_hub import _should_skip_ngd_download
 
 
 def test_filter_zips_for_source_prefers_ngd_named_zips() -> None:
@@ -27,7 +29,7 @@ def test_should_convert_csv_to_parquet_skips_non_ngd_for_ngd_source() -> None:
     assert _should_convert_csv_to_parquet(abp_csv, "ngd") is False
 
 
-def test_filter_zips_for_source_excludes_ngd_historicaddress() -> None:
+def test_filter_zips_for_source_includes_ngd_historicaddress_by_default() -> None:
     zip_files = [
         Path("add_gb_builtaddress.zip"),
         Path("add_gb_historicaddress.zip"),
@@ -39,11 +41,64 @@ def test_filter_zips_for_source_excludes_ngd_historicaddress() -> None:
 
     assert Path("add_gb_builtaddress.zip") in filtered
     assert Path("add_gb_prebuildaddress.zip") in filtered
-    assert Path("add_gb_historicaddress.zip") not in filtered
-    assert Path("add_gb_historicaddress_altadd.zip") not in filtered
+    assert Path("add_gb_historicaddress.zip") in filtered
+    assert Path("add_gb_historicaddress_altadd.zip") in filtered
 
 
-def test_should_convert_csv_to_parquet_skips_ngd_historicaddress() -> None:
+def test_filter_zips_for_source_uses_configured_ngd_exclusions() -> None:
+    zip_files = [
+        Path("add_gb_builtaddress.zip"),
+        Path("add_gb_historicaddress.zip"),
+        Path("add_gb_historicaddress_altadd.zip"),
+        Path("add_gb_prebuildaddress_altadd.zip"),
+    ]
+
+    filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress", "*_altadd"])
+
+    assert filtered == [Path("add_gb_builtaddress.zip")]
+
+
+def test_core_ngd_exclusion_does_not_exclude_altadd_files() -> None:
+    zip_files = [
+        Path("add_gb_historicaddress.zip"),
+        Path("add_gb_historicaddress_altadd.zip"),
+    ]
+
+    filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress"])
+
+    assert filtered == [Path("add_gb_historicaddress_altadd.zip")]
+
+
+def test_should_convert_csv_to_parquet_includes_ngd_historicaddress_by_default() -> None:
     assert _should_convert_csv_to_parquet(Path("add_gb_builtaddress.csv"), "ngd") is True
-    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress.csv"), "ngd") is False
-    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress_altadd.csv"), "ngd") is False
+    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress.csv"), "ngd") is True
+    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress_altadd.csv"), "ngd") is True
+
+
+def test_should_convert_csv_to_parquet_uses_configured_ngd_exclusions() -> None:
+    excluded = ["historicaddress", "*_altadd"]
+
+    assert _should_convert_csv_to_parquet(Path("add_gb_builtaddress.csv"), "ngd", excluded) is True
+    assert (
+        _should_convert_csv_to_parquet(Path("add_gb_historicaddress.csv"), "ngd", excluded)
+        is False
+    )
+    assert (
+        _should_convert_csv_to_parquet(
+            Path("add_gb_historicaddress_altadd.csv"),
+            "ngd",
+            excluded,
+        )
+        is False
+    )
+
+
+def test_should_skip_ngd_download_uses_configured_exclusions() -> None:
+    settings = SimpleNamespace(
+        source=SimpleNamespace(type="ngd"),
+        processing=SimpleNamespace(ngd_excluded_stems=["historicaddress", "*_altadd"]),
+    )
+
+    assert _should_skip_ngd_download("add_gb_historicaddress.zip", settings) is True
+    assert _should_skip_ngd_download("add_gb_historicaddress_altadd.zip", settings) is True
+    assert _should_skip_ngd_download("add_gb_builtaddress.zip", settings) is False

--- a/tests/test_extract_source_filtering.py
+++ b/tests/test_extract_source_filtering.py
@@ -29,7 +29,7 @@ def test_should_convert_csv_to_parquet_skips_non_ngd_for_ngd_source() -> None:
     assert _should_convert_csv_to_parquet(abp_csv, "ngd") is False
 
 
-def test_filter_zips_for_source_includes_ngd_historicaddress_by_default() -> None:
+def test_filter_zips_for_source_includes_historic_with_empty_exclusions() -> None:
     zip_files = [
         Path("add_gb_builtaddress.zip"),
         Path("add_gb_historicaddress.zip"),
@@ -53,7 +53,11 @@ def test_filter_zips_for_source_uses_configured_ngd_exclusions() -> None:
         Path("add_gb_prebuildaddress_altadd.zip"),
     ]
 
-    filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress", "prebuildaddress"])
+    filtered = _filter_zips_for_source(
+        zip_files,
+        "ngd",
+        ["historicaddress", "prebuildaddress"],
+    )
 
     assert filtered == [Path("add_gb_builtaddress.zip")]
 
@@ -69,23 +73,32 @@ def test_core_ngd_exclusion_also_excludes_matching_altadd_files() -> None:
     assert filtered == []
 
 
-def test_should_convert_csv_to_parquet_includes_ngd_historicaddress_by_default() -> None:
-    assert _should_convert_csv_to_parquet(Path("add_gb_builtaddress.csv"), "ngd") is True
-    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress.csv"), "ngd") is True
-    assert _should_convert_csv_to_parquet(Path("add_gb_historicaddress_altadd.csv"), "ngd") is True
+def test_csv_to_parquet_includes_historic_with_empty_exclusions() -> None:
+    assert _should_convert_csv_to_parquet(
+        Path("add_gb_builtaddress.csv"),
+        "ngd",
+    ) is True
+    assert _should_convert_csv_to_parquet(
+        Path("add_gb_historicaddress.csv"),
+        "ngd",
+    ) is True
+    assert _should_convert_csv_to_parquet(
+        Path("add_gb_historicaddress_altadd.csv"),
+        "ngd",
+    ) is True
 
 
 def test_should_convert_csv_to_parquet_uses_configured_ngd_exclusions() -> None:
     excluded = ["historicaddress"]
 
-    assert _should_convert_csv_to_parquet(Path("add_gb_builtaddress.csv"), "ngd", excluded) is True
-    assert (
-        _should_convert_csv_to_parquet(Path("add_gb_historicaddress.csv"), "ngd", excluded)
-        is False
-    )
+    assert _should_convert_csv_to_parquet(
+        Path("add_gb_builtaddress.csv"),
+        "ngd",
+        excluded,
+    ) is True
     assert (
         _should_convert_csv_to_parquet(
-            Path("add_gb_historicaddress_altadd.csv"),
+            Path("add_gb_historicaddress.csv"),
             "ngd",
             excluded,
         )
@@ -100,5 +113,8 @@ def test_should_skip_ngd_download_uses_configured_exclusions() -> None:
     )
 
     assert _should_skip_ngd_download("add_gb_historicaddress.zip", settings) is True
-    assert _should_skip_ngd_download("add_gb_historicaddress_altadd.zip", settings) is True
+    assert (
+        _should_skip_ngd_download("add_gb_historicaddress_altadd.zip", settings)
+        is True
+    )
     assert _should_skip_ngd_download("add_gb_builtaddress.zip", settings) is False

--- a/tests/test_extract_source_filtering.py
+++ b/tests/test_extract_source_filtering.py
@@ -53,12 +53,12 @@ def test_filter_zips_for_source_uses_configured_ngd_exclusions() -> None:
         Path("add_gb_prebuildaddress_altadd.zip"),
     ]
 
-    filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress", "*_altadd"])
+    filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress", "prebuildaddress"])
 
     assert filtered == [Path("add_gb_builtaddress.zip")]
 
 
-def test_core_ngd_exclusion_does_not_exclude_altadd_files() -> None:
+def test_core_ngd_exclusion_also_excludes_matching_altadd_files() -> None:
     zip_files = [
         Path("add_gb_historicaddress.zip"),
         Path("add_gb_historicaddress_altadd.zip"),
@@ -66,7 +66,7 @@ def test_core_ngd_exclusion_does_not_exclude_altadd_files() -> None:
 
     filtered = _filter_zips_for_source(zip_files, "ngd", ["historicaddress"])
 
-    assert filtered == [Path("add_gb_historicaddress_altadd.zip")]
+    assert filtered == []
 
 
 def test_should_convert_csv_to_parquet_includes_ngd_historicaddress_by_default() -> None:
@@ -76,7 +76,7 @@ def test_should_convert_csv_to_parquet_includes_ngd_historicaddress_by_default()
 
 
 def test_should_convert_csv_to_parquet_uses_configured_ngd_exclusions() -> None:
-    excluded = ["historicaddress", "*_altadd"]
+    excluded = ["historicaddress"]
 
     assert _should_convert_csv_to_parquet(Path("add_gb_builtaddress.csv"), "ngd", excluded) is True
     assert (
@@ -96,7 +96,7 @@ def test_should_convert_csv_to_parquet_uses_configured_ngd_exclusions() -> None:
 def test_should_skip_ngd_download_uses_configured_exclusions() -> None:
     settings = SimpleNamespace(
         source=SimpleNamespace(type="ngd"),
-        processing=SimpleNamespace(ngd_excluded_stems=["historicaddress", "*_altadd"]),
+        processing=SimpleNamespace(ngd_excluded_stems=["historicaddress"]),
     )
 
     assert _should_skip_ngd_download("add_gb_historicaddress.zip", settings) is True

--- a/tests/test_ngd_exclusions.py
+++ b/tests/test_ngd_exclusions.py
@@ -18,7 +18,10 @@ def test_ngd_excluded_stems_normalise_and_dedupe() -> None:
 def test_ngd_core_exclusion_matches_core_file_and_altadd_file() -> None:
     excluded = ["historicaddress"]
 
-    assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is True
+    assert (
+        ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded)
+        is True
+    )
     assert (
         ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded)
         is True
@@ -28,9 +31,18 @@ def test_ngd_core_exclusion_matches_core_file_and_altadd_file() -> None:
 def test_ngd_feature_exclusion_only_matches_its_own_altadd_file() -> None:
     excluded = ["builtaddress"]
 
-    assert ngd_file_matches_excluded_stem("add_gb_builtaddress_altadd.zip", excluded) is True
-    assert ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded) is False
-    assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is False
+    assert (
+        ngd_file_matches_excluded_stem("add_gb_builtaddress_altadd.zip", excluded)
+        is True
+    )
+    assert (
+        ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded)
+        is False
+    )
+    assert (
+        ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded)
+        is False
+    )
 
 
 def test_ngd_excluded_stems_reject_unknown_stem() -> None:

--- a/tests/test_ngd_exclusions.py
+++ b/tests/test_ngd_exclusions.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    ngd_file_matches_excluded_stem,
+    parse_ngd_excluded_stems,
+)
+
+
+def test_ngd_excluded_stems_normalise_and_dedupe() -> None:
+    assert parse_ngd_excluded_stems("HistoricAddress,*_ALTADD,historicaddress") == [
+        "historicaddress",
+        "*_altadd",
+    ]
+
+
+def test_ngd_core_exclusion_matches_exact_core_file_only() -> None:
+    excluded = ["historicaddress"]
+
+    assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is True
+    assert (
+        ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded)
+        is False
+    )
+
+
+def test_ngd_altadd_exclusion_matches_all_alternate_address_files() -> None:
+    excluded = ["*_altadd"]
+
+    assert ngd_file_matches_excluded_stem("add_gb_builtaddress_altadd.zip", excluded) is True
+    assert ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded) is True
+    assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is False
+
+
+def test_ngd_excluded_stems_reject_unknown_stem() -> None:
+    with pytest.raises(ValueError, match="invalid NGD excluded stem"):
+        parse_ngd_excluded_stems("not-a-feature")

--- a/tests/test_ngd_exclusions.py
+++ b/tests/test_ngd_exclusions.py
@@ -9,30 +9,34 @@ from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
 
 
 def test_ngd_excluded_stems_normalise_and_dedupe() -> None:
-    assert parse_ngd_excluded_stems("HistoricAddress,*_ALTADD,historicaddress") == [
+    assert parse_ngd_excluded_stems("HistoricAddress,prebuildaddress,historicaddress") == [
         "historicaddress",
-        "*_altadd",
+        "prebuildaddress",
     ]
 
 
-def test_ngd_core_exclusion_matches_exact_core_file_only() -> None:
+def test_ngd_core_exclusion_matches_core_file_and_altadd_file() -> None:
     excluded = ["historicaddress"]
 
     assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is True
     assert (
         ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded)
-        is False
+        is True
     )
 
 
-def test_ngd_altadd_exclusion_matches_all_alternate_address_files() -> None:
-    excluded = ["*_altadd"]
+def test_ngd_feature_exclusion_only_matches_its_own_altadd_file() -> None:
+    excluded = ["builtaddress"]
 
     assert ngd_file_matches_excluded_stem("add_gb_builtaddress_altadd.zip", excluded) is True
-    assert ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded) is True
+    assert ngd_file_matches_excluded_stem("add_gb_historicaddress_altadd.zip", excluded) is False
     assert ngd_file_matches_excluded_stem("add_gb_historicaddress.zip", excluded) is False
 
 
 def test_ngd_excluded_stems_reject_unknown_stem() -> None:
     with pytest.raises(ValueError, match="invalid NGD excluded stem"):
         parse_ngd_excluded_stems("not-a-feature")
+
+def test_ngd_excluded_stems_reject_altadd_wildcard() -> None:
+    with pytest.raises(ValueError, match="invalid NGD excluded stem"):
+        parse_ngd_excluded_stems("*_altadd")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -194,6 +194,120 @@ def test_load_settings_defaults_source_and_num_chunks(
 
     assert settings.source.type == "ngd"
     assert settings.processing.num_chunks == 20
+    assert settings.processing.ngd_excluded_stems == []
+    assert settings.processing.abp_excluded_logical_statuses == []
+
+
+def test_load_settings_validates_ngd_excluded_stems(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OS_PROJECT_API_KEY", "key")
+    monkeypatch.setenv("OS_PROJECT_API_SECRET", "secret")
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        """
+        os_downloads:
+          package_id: "16465"
+          version_id: "104444"
+
+        processing:
+          ngd_excluded_stems:
+            - HistoricAddress
+            - "*_ALTADD"
+            - historicaddress
+        """,
+    )
+
+    settings = load_settings(config_path, load_env=False)
+
+    assert settings.processing.ngd_excluded_stems == ["historicaddress", "*_altadd"]
+
+
+def test_load_settings_rejects_invalid_ngd_excluded_stem(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OS_PROJECT_API_KEY", "key")
+    monkeypatch.setenv("OS_PROJECT_API_SECRET", "secret")
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        """
+        os_downloads:
+          package_id: "16465"
+          version_id: "104444"
+
+        processing:
+          ngd_excluded_stems:
+            - not-a-feature
+        """,
+    )
+
+    with pytest.raises(SettingsError) as exc_info:
+        load_settings(config_path, load_env=False)
+
+    assert exc_info.value.validation_error is not None
+    assert "ngd_excluded_stems" in str(exc_info.value.validation_error)
+
+
+def test_load_settings_validates_abp_excluded_logical_statuses(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OS_PROJECT_API_KEY", "key")
+    monkeypatch.setenv("OS_PROJECT_API_SECRET", "secret")
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        """
+        os_downloads:
+          package_id: "16465"
+          version_id: "104444"
+
+        processing:
+          abp_excluded_logical_statuses:
+            - "8"
+            - 3
+            - 8
+        """,
+    )
+
+    settings = load_settings(config_path, load_env=False)
+
+    assert settings.processing.abp_excluded_logical_statuses == [8, 3]
+
+
+def test_load_settings_rejects_invalid_abp_excluded_logical_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("OS_PROJECT_API_KEY", "key")
+    monkeypatch.setenv("OS_PROJECT_API_SECRET", "secret")
+
+    config_path = tmp_path / "config.yaml"
+    _write_config(
+        config_path,
+        """
+        os_downloads:
+          package_id: "16465"
+          version_id: "104444"
+
+        processing:
+          abp_excluded_logical_statuses:
+            - 2
+        """,
+    )
+
+    with pytest.raises(SettingsError) as exc_info:
+        load_settings(config_path, load_env=False)
+
+    assert exc_info.value.validation_error is not None
+    assert "abp_excluded_logical_statuses" in str(exc_info.value.validation_error)
 
 
 def test_load_settings_applies_path_overrides(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -194,8 +194,8 @@ def test_load_settings_defaults_source_and_num_chunks(
 
     assert settings.source.type == "ngd"
     assert settings.processing.num_chunks == 20
-    assert settings.processing.ngd_excluded_stems == []
-    assert settings.processing.abp_excluded_logical_statuses == []
+    assert settings.processing.ngd_excluded_stems == ["historicaddress"]
+    assert settings.processing.abp_excluded_logical_statuses == [8]
 
 
 def test_load_settings_validates_ngd_excluded_stems(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -216,14 +216,14 @@ def test_load_settings_validates_ngd_excluded_stems(
         processing:
           ngd_excluded_stems:
             - HistoricAddress
-            - "*_ALTADD"
+            - prebuildaddress
             - historicaddress
         """,
     )
 
     settings = load_settings(config_path, load_env=False)
 
-    assert settings.processing.ngd_excluded_stems == ["historicaddress", "*_altadd"]
+    assert settings.processing.ngd_excluded_stems == ["historicaddress", "prebuildaddress"]
 
 
 def test_load_settings_rejects_invalid_ngd_excluded_stem(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -119,6 +119,7 @@ def _prepare_test_parquet(settings: Settings) -> None:
     sample_files = [
         "add_gb_builtaddress.csv",
         "add_gb_builtaddress_altadd.csv",
+        "add_gb_historicaddress.csv",
         "add_gb_royalmailaddress.csv",
         "add_gb_prebuildaddress.csv",
     ]
@@ -183,6 +184,12 @@ def test_flatfile_single_chunk(temp_settings: Settings) -> None:
     ]
     for col in expected_columns:
         assert col in column_names, f"Column {col} should exist in output"
+
+    historic_count = con.execute(f"""
+        SELECT COUNT(*) FROM read_parquet('{output_files[0].as_posix()}')
+        WHERE filename = 'add_gb_historicaddress.parquet'
+    """).fetchone()[0]
+    assert historic_count > 0, "Historic Address records should be processed by default"
 
     con.close()
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -55,6 +55,7 @@ def temp_settings() -> Generator[Settings, None, None]:
             parquet_compression="zstd",
             parquet_compression_level=1,  # Faster for tests
             num_chunks=1,
+            ngd_excluded_stems=[],
         )
 
         settings = Settings(
@@ -99,6 +100,7 @@ def temp_settings_chunked() -> Generator[Settings, None, None]:
             parquet_compression="zstd",
             parquet_compression_level=1,
             num_chunks=2,
+            ngd_excluded_stems=[],
         )
 
         settings = Settings(
@@ -189,7 +191,9 @@ def test_flatfile_single_chunk(temp_settings: Settings) -> None:
         SELECT COUNT(*) FROM read_parquet('{output_files[0].as_posix()}')
         WHERE filename = 'add_gb_historicaddress.parquet'
     """).fetchone()[0]
-    assert historic_count > 0, "Historic Address records should be processed by default"
+    assert (
+        historic_count > 0
+    ), "Historic Address records should be processed when included"
 
     con.close()
 

--- a/ukam_os_builder/api/api.py
+++ b/ukam_os_builder/api/api.py
@@ -9,11 +9,13 @@ import requests
 import yaml
 
 from ukam_os_builder.data_sources.abp.abp_exclusions import (
+    DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES,
     format_valid_abp_excluded_logical_statuses,
     parse_abp_excluded_logical_statuses,
 )
 
 from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    DEFAULT_NGD_EXCLUDED_STEMS,
     format_valid_ngd_excluded_stems,
     parse_ngd_excluded_stems,
 )
@@ -45,8 +47,10 @@ def _default_config() -> dict[str, object]:
             "parquet_compression": "zstd",
             "parquet_compression_level": 9,
             "num_chunks": 20,
-            "ngd_excluded_stems": [],
-            "abp_excluded_logical_statuses": [],
+            "ngd_excluded_stems": list(DEFAULT_NGD_EXCLUDED_STEMS),
+            "abp_excluded_logical_statuses": list(
+                DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES
+            ),
         },
     }
 
@@ -76,6 +80,14 @@ def render_annotated_config(config: dict[str, object]) -> str:
     ngd_excluded_stems = parse_ngd_excluded_stems(processing.get("ngd_excluded_stems"))
     abp_excluded_logical_statuses = parse_abp_excluded_logical_statuses(
         processing.get("abp_excluded_logical_statuses")
+    )
+    ngd_excluded_stems_yaml = _render_yaml_list(
+        "ngd_excluded_stems",
+        ngd_excluded_stems,
+    )
+    abp_excluded_logical_statuses_yaml = _render_yaml_list(
+        "abp_excluded_logical_statuses",
+        abp_excluded_logical_statuses,
     )
 
     duckdb_memory_limit = processing.get("duckdb_memory_limit")
@@ -122,13 +134,15 @@ def render_annotated_config(config: dict[str, object]) -> str:
         "  # Number of chunks to split flatfile processing into (default: 1)\n"
         "  # Use higher values (e.g., 10-20) for lower memory usage\n"
         f"  num_chunks: {processing['num_chunks']}\n\n"
-        "  # NGD feature stems to exclude from download, extract, and flatfile processing\n"
+        "  # NGD feature stems to exclude from pipeline processing\n"
+        "  # (Historic addresses are excluded by default)\n"
         f"  # Valid values: {format_valid_ngd_excluded_stems()}\n"
-        f"{_render_yaml_list('ngd_excluded_stems', ngd_excluded_stems)}\n"
+        f"{ngd_excluded_stems_yaml}\n"
         "  # ABP LPI logical statuses to exclude from flatfile processing\n"
+        "  # (Logical status 8 is excluded by default)\n"
         f"  # Valid values: {format_valid_abp_excluded_logical_statuses()} "
         "(1=approved, 3=alternative, 6=provisional, 8=historic)\n"
-        f"{_render_yaml_list('abp_excluded_logical_statuses', abp_excluded_logical_statuses)}"
+        f"{abp_excluded_logical_statuses_yaml}"
     )
 
 

--- a/ukam_os_builder/api/api.py
+++ b/ukam_os_builder/api/api.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal
 
@@ -28,26 +27,31 @@ logger = logging.getLogger(__name__)
 
 SourceType = Literal["ngd", "abp"]
 
-DEFAULT_CONFIG: dict[str, object] = {
-    "paths": {
-        "work_dir": "./data",
-        "overrides": {},
-    },
-    "source": {
-        "type": "ngd",
-    },
-    "os_downloads": {
-        "package_id": "",
-        "version_id": "",
-    },
-    "processing": {
-        "parquet_compression": "zstd",
-        "parquet_compression_level": 9,
-        "num_chunks": 20,
-        "ngd_excluded_stems": [],
-        "abp_excluded_logical_statuses": [],
-    },
-}
+def _default_config() -> dict[str, object]:
+    """Return fresh default config values."""
+    return {
+        "paths": {
+            "work_dir": "./data",
+            "overrides": {},
+        },
+        "source": {
+            "type": "ngd",
+        },
+        "os_downloads": {
+            "package_id": "",
+            "version_id": "",
+        },
+        "processing": {
+            "parquet_compression": "zstd",
+            "parquet_compression_level": 9,
+            "num_chunks": 20,
+            "ngd_excluded_stems": [],
+            "abp_excluded_logical_statuses": [],
+        },
+    }
+
+
+DEFAULT_CONFIG: dict[str, object] = _default_config()
 
 
 def _render_yaml_list(key: str, values: list[object], *, indent: int = 2) -> str:
@@ -130,25 +134,26 @@ def render_annotated_config(config: dict[str, object]) -> str:
 
 def load_existing_defaults(config_path: Path) -> dict[str, object]:
     """Load existing config as defaults, merged with built-in defaults."""
+    defaults = _default_config()
     if not config_path.exists():
-        return deepcopy(DEFAULT_CONFIG)
+        return defaults
 
     with open(config_path) as f:
         loaded = yaml.safe_load(f) or {}
 
-    merged = deepcopy(DEFAULT_CONFIG) | loaded
+    merged = defaults | loaded
     loaded_paths = loaded.get("paths") if isinstance(loaded.get("paths"), dict) else {}
     merged["paths"] = {
-        "work_dir": loaded_paths.get("work_dir", DEFAULT_CONFIG["paths"]["work_dir"]),
+        "work_dir": loaded_paths.get("work_dir", defaults["paths"]["work_dir"]),
         "overrides": dict(loaded_paths.get("overrides") or {}),
     }
-    merged["source"] = {**deepcopy(DEFAULT_CONFIG["source"]), **(loaded.get("source") or {})}
+    merged["source"] = {**defaults["source"], **(loaded.get("source") or {})}
     merged["os_downloads"] = {
-        **deepcopy(DEFAULT_CONFIG["os_downloads"]),
+        **defaults["os_downloads"],
         **(loaded.get("os_downloads") or {}),
     }
     merged["processing"] = {
-        **deepcopy(DEFAULT_CONFIG["processing"]),
+        **defaults["processing"],
         **(loaded.get("processing") or {}),
     }
     return merged

--- a/ukam_os_builder/api/api.py
+++ b/ukam_os_builder/api/api.py
@@ -8,19 +8,17 @@ from typing import Any, Literal
 import requests
 import yaml
 
+from ukam_os_builder.api.settings import Settings, SettingsError, load_settings
 from ukam_os_builder.data_sources.abp.abp_exclusions import (
     DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES,
     format_valid_abp_excluded_logical_statuses,
     parse_abp_excluded_logical_statuses,
 )
-
 from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
     DEFAULT_NGD_EXCLUDED_STEMS,
     format_valid_ngd_excluded_stems,
     parse_ngd_excluded_stems,
 )
-
-from ukam_os_builder.api.settings import Settings, SettingsError, load_settings
 from ukam_os_builder.os_builder.os_hub import _get_manifest_path, get_package_version
 from ukam_os_builder.pipeline import run as run_pipeline
 from ukam_os_builder.pipeline import supported_steps_for_source

--- a/ukam_os_builder/api/api.py
+++ b/ukam_os_builder/api/api.py
@@ -2,11 +2,22 @@ from __future__ import annotations
 
 import logging
 import os
+from copy import deepcopy
 from pathlib import Path
 from typing import Any, Literal
 
 import requests
 import yaml
+
+from ukam_os_builder.data_sources.abp.abp_exclusions import (
+    format_valid_abp_excluded_logical_statuses,
+    parse_abp_excluded_logical_statuses,
+)
+
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    format_valid_ngd_excluded_stems,
+    parse_ngd_excluded_stems,
+)
 
 from ukam_os_builder.api.settings import Settings, SettingsError, load_settings
 from ukam_os_builder.os_builder.os_hub import _get_manifest_path, get_package_version
@@ -33,8 +44,24 @@ DEFAULT_CONFIG: dict[str, object] = {
         "parquet_compression": "zstd",
         "parquet_compression_level": 9,
         "num_chunks": 20,
+        "ngd_excluded_stems": [],
+        "abp_excluded_logical_statuses": [],
     },
 }
+
+
+def _render_yaml_list(key: str, values: list[object], *, indent: int = 2) -> str:
+    prefix = " " * indent
+    item_prefix = " " * (indent + 2)
+    if not values:
+        return f"{prefix}{key}: []\n"
+
+    lines = [f"{prefix}{key}:"]
+    for value in values:
+        value_text = str(value)
+        rendered_value = f'"{value_text}"' if value_text.startswith("*") else value_text
+        lines.append(f"{item_prefix}- {rendered_value}")
+    return "\n".join(lines) + "\n"
 
 
 def render_annotated_config(config: dict[str, object]) -> str:
@@ -42,6 +69,10 @@ def render_annotated_config(config: dict[str, object]) -> str:
     paths = config["paths"]
     os_downloads = config["os_downloads"]
     processing = config["processing"]
+    ngd_excluded_stems = parse_ngd_excluded_stems(processing.get("ngd_excluded_stems"))
+    abp_excluded_logical_statuses = parse_abp_excluded_logical_statuses(
+        processing.get("abp_excluded_logical_statuses")
+    )
 
     duckdb_memory_limit = processing.get("duckdb_memory_limit")
     duckdb_memory_limit_line = (
@@ -86,31 +117,38 @@ def render_annotated_config(config: dict[str, object]) -> str:
         f"{duckdb_memory_limit_line}\n"
         "  # Number of chunks to split flatfile processing into (default: 1)\n"
         "  # Use higher values (e.g., 10-20) for lower memory usage\n"
-        f"  num_chunks: {processing['num_chunks']}\n"
+        f"  num_chunks: {processing['num_chunks']}\n\n"
+        "  # NGD feature stems to exclude from download, extract, and flatfile processing\n"
+        f"  # Valid values: {format_valid_ngd_excluded_stems()}\n"
+        f"{_render_yaml_list('ngd_excluded_stems', ngd_excluded_stems)}\n"
+        "  # ABP LPI logical statuses to exclude from flatfile processing\n"
+        f"  # Valid values: {format_valid_abp_excluded_logical_statuses()} "
+        "(1=approved, 3=alternative, 6=provisional, 8=historic)\n"
+        f"{_render_yaml_list('abp_excluded_logical_statuses', abp_excluded_logical_statuses)}"
     )
 
 
 def load_existing_defaults(config_path: Path) -> dict[str, object]:
     """Load existing config as defaults, merged with built-in defaults."""
     if not config_path.exists():
-        return DEFAULT_CONFIG.copy()
+        return deepcopy(DEFAULT_CONFIG)
 
     with open(config_path) as f:
         loaded = yaml.safe_load(f) or {}
 
-    merged = DEFAULT_CONFIG | loaded
+    merged = deepcopy(DEFAULT_CONFIG) | loaded
     loaded_paths = loaded.get("paths") if isinstance(loaded.get("paths"), dict) else {}
     merged["paths"] = {
         "work_dir": loaded_paths.get("work_dir", DEFAULT_CONFIG["paths"]["work_dir"]),
         "overrides": dict(loaded_paths.get("overrides") or {}),
     }
-    merged["source"] = {**DEFAULT_CONFIG["source"], **(loaded.get("source") or {})}
+    merged["source"] = {**deepcopy(DEFAULT_CONFIG["source"]), **(loaded.get("source") or {})}
     merged["os_downloads"] = {
-        **DEFAULT_CONFIG["os_downloads"],
+        **deepcopy(DEFAULT_CONFIG["os_downloads"]),
         **(loaded.get("os_downloads") or {}),
     }
     merged["processing"] = {
-        **DEFAULT_CONFIG["processing"],
+        **deepcopy(DEFAULT_CONFIG["processing"]),
         **(loaded.get("processing") or {}),
     }
     return merged
@@ -193,6 +231,8 @@ def create_config_and_env(
     overwrite_env: bool = False,
     paths: dict[str, str] | None = None,
     processing: dict[str, Any] | None = None,
+    ngd_excluded_stems: list[str] | None = None,
+    abp_excluded_logical_statuses: list[int] | None = None,
     api_key: str | None = None,
     api_secret: str | None = None,
 ) -> tuple[Path, Path, bool]:
@@ -213,6 +253,14 @@ def create_config_and_env(
         config["paths"] = {**config["paths"], **paths}
     if processing:
         config["processing"] = {**config["processing"], **processing}
+    if ngd_excluded_stems is not None:
+        config["processing"]["ngd_excluded_stems"] = parse_ngd_excluded_stems(
+            ngd_excluded_stems
+        )
+    if abp_excluded_logical_statuses is not None:
+        config["processing"]["abp_excluded_logical_statuses"] = (
+            parse_abp_excluded_logical_statuses(abp_excluded_logical_statuses)
+        )
 
     return write_config_and_env(
         config=config,
@@ -239,6 +287,8 @@ def apply_run_overrides(
     duckdb_memory_limit: str | None = None,
     parquet_compression: str | None = None,
     parquet_compression_level: int | None = None,
+    ngd_excluded_stems: str | list[str] | None = None,
+    abp_excluded_logical_statuses: str | list[int] | None = None,
 ) -> None:
     """Apply runtime overrides to loaded settings."""
     if source:
@@ -278,6 +328,16 @@ def apply_run_overrides(
     if parquet_compression_level is not None:
         settings.processing.parquet_compression_level = parquet_compression_level
 
+    if ngd_excluded_stems is not None:
+        settings.processing.ngd_excluded_stems = parse_ngd_excluded_stems(
+            ngd_excluded_stems
+        )
+
+    if abp_excluded_logical_statuses is not None:
+        settings.processing.abp_excluded_logical_statuses = (
+            parse_abp_excluded_logical_statuses(abp_excluded_logical_statuses)
+        )
+
 
 def run_from_config(
     config_path: str | Path,
@@ -299,6 +359,8 @@ def run_from_config(
     duckdb_memory_limit: str | None = None,
     parquet_compression: str | None = None,
     parquet_compression_level: int | None = None,
+    ngd_excluded_stems: str | list[str] | None = None,
+    abp_excluded_logical_statuses: str | list[int] | None = None,
     api_key: str | None = None,
     api_secret: str | None = None,
     check_api: bool = True,
@@ -332,6 +394,8 @@ def run_from_config(
         duckdb_memory_limit=duckdb_memory_limit,
         parquet_compression=parquet_compression,
         parquet_compression_level=parquet_compression_level,
+        ngd_excluded_stems=ngd_excluded_stems,
+        abp_excluded_logical_statuses=abp_excluded_logical_statuses,
     )
     logger.info("Resolved work_dir: %s", settings.paths.work_dir)
     source_type = settings.source.type

--- a/ukam_os_builder/api/settings.py
+++ b/ukam_os_builder/api/settings.py
@@ -8,7 +8,10 @@ from typing import Any, Literal
 import duckdb
 import yaml
 from dotenv import load_dotenv
-from pydantic import BaseModel, ConfigDict, SecretStr, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError, field_validator
+
+from ukam_os_builder.data_sources.abp.abp_exclusions import normalise_abp_excluded_logical_statuses
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import normalise_ngd_excluded_stems
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +81,8 @@ class ProcessingSettings(StrictBaseModel):
     parquet_compression_level: int = 9
     duckdb_memory_limit: str | None = None
     num_chunks: int = 20
+    ngd_excluded_stems: list[str] = Field(default_factory=list)
+    abp_excluded_logical_statuses: list[int] = Field(default_factory=list)
 
     @field_validator("num_chunks")
     @classmethod
@@ -85,6 +90,20 @@ class ProcessingSettings(StrictBaseModel):
         if value < 1:
             raise ValueError("must be >= 1")
         return value
+
+    @field_validator("ngd_excluded_stems", mode="before")
+    @classmethod
+    def _validate_ngd_excluded_stems(cls, value: Any) -> list[str]:
+        if isinstance(value, str):
+            raise ValueError("must be a list of NGD feature stems")
+        return normalise_ngd_excluded_stems(value)
+
+    @field_validator("abp_excluded_logical_statuses", mode="before")
+    @classmethod
+    def _validate_abp_excluded_logical_statuses(cls, value: Any) -> list[int]:
+        if isinstance(value, str):
+            raise ValueError("must be a list of ABP logical statuses")
+        return normalise_abp_excluded_logical_statuses(value)
 
 
 class Settings(StrictBaseModel):

--- a/ukam_os_builder/api/settings.py
+++ b/ukam_os_builder/api/settings.py
@@ -10,8 +10,14 @@ import yaml
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError, field_validator
 
-from ukam_os_builder.data_sources.abp.abp_exclusions import normalise_abp_excluded_logical_statuses
-from ukam_os_builder.data_sources.ngd.ngd_exclusions import normalise_ngd_excluded_stems
+from ukam_os_builder.data_sources.abp.abp_exclusions import (
+    DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES,
+    normalise_abp_excluded_logical_statuses,
+)
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    DEFAULT_NGD_EXCLUDED_STEMS,
+    normalise_ngd_excluded_stems,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +87,12 @@ class ProcessingSettings(StrictBaseModel):
     parquet_compression_level: int = 9
     duckdb_memory_limit: str | None = None
     num_chunks: int = 20
-    ngd_excluded_stems: list[str] = Field(default_factory=list)
-    abp_excluded_logical_statuses: list[int] = Field(default_factory=list)
+    ngd_excluded_stems: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_NGD_EXCLUDED_STEMS)
+    )
+    abp_excluded_logical_statuses: list[int] = Field(
+        default_factory=lambda: list(DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES)
+    )
 
     @field_validator("num_chunks")
     @classmethod

--- a/ukam_os_builder/cli.py
+++ b/ukam_os_builder/cli.py
@@ -98,6 +98,21 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         help="Override processing.parquet_compression_level.",
     )
+    parser.add_argument(
+        "--ngd-excluded-stems",
+        help=(
+            "Comma-separated NGD feature stems to exclude "
+            "(builtaddress, prebuildaddress, historicaddress, nonaddressableobject, "
+            "royalmailaddress, *_altadd)."
+        ),
+    )
+    parser.add_argument(
+        "--abp-excluded-logical-statuses",
+        help=(
+            "Comma-separated ABP LPI logical statuses to exclude "
+            "(1=approved, 3=alternative, 6=provisional, 8=historic)."
+        ),
+    )
 
     parser.add_argument(
         "--verbose",
@@ -144,6 +159,8 @@ def main(argv: list[str] | None = None) -> int:
             duckdb_memory_limit=args.duckdb_memory_limit,
             parquet_compression=args.parquet_compression,
             parquet_compression_level=args.parquet_compression_level,
+            ngd_excluded_stems=args.ngd_excluded_stems,
+            abp_excluded_logical_statuses=args.abp_excluded_logical_statuses,
         )
         console.print("[bold green]Build completed successfully[/bold green]")
         return 0

--- a/ukam_os_builder/cli.py
+++ b/ukam_os_builder/cli.py
@@ -104,14 +104,14 @@ def _build_parser() -> argparse.ArgumentParser:
             "Comma-separated NGD feature stems to exclude "
             "(builtaddress, prebuildaddress, historicaddress, nonaddressableobject, "
             "royalmailaddress). Matching alternate-address files are excluded with "
-            "their feature stem."
+            "their feature stem. Default: historicaddress"
         ),
     )
     parser.add_argument(
         "--abp-excluded-logical-statuses",
         help=(
             "Comma-separated ABP LPI logical statuses to exclude "
-            "(1=approved, 3=alternative, 6=provisional, 8=historic)."
+            "(1=approved, 3=alternative, 6=provisional, 8=historic). Default: 8"
         ),
     )
 

--- a/ukam_os_builder/cli.py
+++ b/ukam_os_builder/cli.py
@@ -103,7 +103,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Comma-separated NGD feature stems to exclude "
             "(builtaddress, prebuildaddress, historicaddress, nonaddressableobject, "
-            "royalmailaddress, *_altadd)."
+            "royalmailaddress). Matching alternate-address files are excluded with "
+            "their feature stem."
         ),
     )
     parser.add_argument(

--- a/ukam_os_builder/data_sources/abp/abp_exclusions.py
+++ b/ukam_os_builder/data_sources/abp/abp_exclusions.py
@@ -5,6 +5,7 @@ from typing import Any
 
 ABP_SUPPORTED_LOGICAL_STATUSES = (1, 3, 6, 8)
 VALID_ABP_EXCLUDED_LOGICAL_STATUSES = frozenset(ABP_SUPPORTED_LOGICAL_STATUSES)
+DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES = (8,)
 
 
 def format_valid_abp_excluded_logical_statuses() -> str:
@@ -51,7 +52,9 @@ def parse_abp_excluded_logical_statuses(value: str | Iterable[Any] | None) -> li
     if isinstance(value, str):
         if not value.strip():
             return []
-        return normalise_abp_excluded_logical_statuses(part.strip() for part in value.split(","))
+        return normalise_abp_excluded_logical_statuses(
+            part.strip() for part in value.split(",")
+        )
     return normalise_abp_excluded_logical_statuses(value)
 
 
@@ -59,11 +62,19 @@ def get_configured_abp_excluded_logical_statuses(settings: Any) -> list[int]:
     """Read configured ABP logical status exclusions from a settings-like object."""
     processing = getattr(settings, "processing", None)
     return normalise_abp_excluded_logical_statuses(
-        getattr(processing, "abp_excluded_logical_statuses", [])
+        getattr(
+            processing,
+            "abp_excluded_logical_statuses",
+            DEFAULT_ABP_EXCLUDED_LOGICAL_STATUSES,
+        )
     )
 
 
 def included_abp_logical_statuses(excluded_statuses: Iterable[Any] | None) -> list[int]:
     """Return supported ABP LPI logical status after configured exclusions."""
     excluded = set(normalise_abp_excluded_logical_statuses(excluded_statuses))
-    return [status for status in ABP_SUPPORTED_LOGICAL_STATUSES if status not in excluded]
+    return [
+        status
+        for status in ABP_SUPPORTED_LOGICAL_STATUSES
+        if status not in excluded
+    ]

--- a/ukam_os_builder/data_sources/abp/abp_exclusions.py
+++ b/ukam_os_builder/data_sources/abp/abp_exclusions.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+ABP_SUPPORTED_LOGICAL_STATUSES = (1, 3, 6, 8)
+VALID_ABP_EXCLUDED_LOGICAL_STATUSES = frozenset(ABP_SUPPORTED_LOGICAL_STATUSES)
+
+
+def format_valid_abp_excluded_logical_statuses() -> str:
+    """Return valid ABP logical status options for messages and help text."""
+    return ", ".join(str(status) for status in ABP_SUPPORTED_LOGICAL_STATUSES)
+
+
+def normalise_abp_excluded_logical_statuses(values: Iterable[Any] | None) -> list[int]:
+    """Validate and normalise ABP logical statuses to exclude."""
+    if values is None:
+        return []
+
+    normalised: list[int] = []
+    seen: set[int] = set()
+    for raw_value in values:
+        if isinstance(raw_value, bool):
+            raise ValueError("abp_excluded_logical_statuses entries must be integers")
+
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "abp_excluded_logical_statuses entries must be integers"
+            ) from exc
+
+        if value not in VALID_ABP_EXCLUDED_LOGICAL_STATUSES:
+            raise ValueError(
+                "invalid ABP excluded logical status "
+                f"{raw_value!r}; valid options are: "
+                f"{format_valid_abp_excluded_logical_statuses()}"
+            )
+
+        if value not in seen:
+            normalised.append(value)
+            seen.add(value)
+
+    return normalised
+
+
+def parse_abp_excluded_logical_statuses(value: str | Iterable[Any] | None) -> list[int]:
+    """Parse CLI/API exclusion input into validated ABP logical status."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        if not value.strip():
+            return []
+        return normalise_abp_excluded_logical_statuses(part.strip() for part in value.split(","))
+    return normalise_abp_excluded_logical_statuses(value)
+
+
+def get_configured_abp_excluded_logical_statuses(settings: Any) -> list[int]:
+    """Read configured ABP logical status exclusions from a settings-like object."""
+    processing = getattr(settings, "processing", None)
+    return normalise_abp_excluded_logical_statuses(
+        getattr(processing, "abp_excluded_logical_statuses", [])
+    )
+
+
+def included_abp_logical_statuses(excluded_statuses: Iterable[Any] | None) -> list[int]:
+    """Return supported ABP LPI logical status after configured exclusions."""
+    excluded = set(normalise_abp_excluded_logical_statuses(excluded_statuses))
+    return [status for status in ABP_SUPPORTED_LOGICAL_STATUSES if status not in excluded]

--- a/ukam_os_builder/data_sources/abp/transform/runner.py
+++ b/ukam_os_builder/data_sources/abp/transform/runner.py
@@ -27,8 +27,10 @@ import logging
 from pathlib import Path
 from time import perf_counter
 
-from ukam_os_builder.data_sources.abp.abp_exclusions import get_configured_abp_excluded_logical_statuses
 from ukam_os_builder.api.settings import Settings, create_duckdb_connection
+from ukam_os_builder.data_sources.abp.abp_exclusions import (
+    get_configured_abp_excluded_logical_statuses,
+)
 from ukam_os_builder.data_sources.abp.transform.common import (
     assert_inputs_exist,
     chunk_where,

--- a/ukam_os_builder/data_sources/abp/transform/runner.py
+++ b/ukam_os_builder/data_sources/abp/transform/runner.py
@@ -27,6 +27,7 @@ import logging
 from pathlib import Path
 from time import perf_counter
 
+from ukam_os_builder.data_sources.abp.abp_exclusions import get_configured_abp_excluded_logical_statuses
 from ukam_os_builder.api.settings import Settings, create_duckdb_connection
 from ukam_os_builder.data_sources.abp.transform.common import (
     assert_inputs_exist,
@@ -146,7 +147,10 @@ def _transform_to_flatfile_chunk(
     """)
     lpi.prepare_street_descriptor_views(con, usrn_filter_view="usrns_in_chunk")
 
-    lpi.prepare_lpi_base(con)
+    lpi.prepare_lpi_base(
+        con,
+        excluded_logical_statuses=get_configured_abp_excluded_logical_statuses(settings),
+    )
     postal.prepare_best_delivery(con)
     misc.prepare_classification_best(con)
     logger.debug("Preparation completed in %.2f seconds", perf_counter() - t0)

--- a/ukam_os_builder/data_sources/abp/transform/stages/combine.py
+++ b/ukam_os_builder/data_sources/abp/transform/stages/combine.py
@@ -33,7 +33,7 @@ def combine_and_dedupe(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyRelatio
         ),
         ranked AS (
             SELECT *,
-                CASE logical_status WHEN 1 THEN 0 WHEN 3 THEN 1 WHEN 6 THEN 2 ELSE 9 END AS status_rank,
+                CASE logical_status WHEN 1 THEN 0 WHEN 3 THEN 1 WHEN 6 THEN 2 WHEN 8 THEN 3 ELSE 9 END AS status_rank,
                 CASE source WHEN 'LPI' THEN 0 WHEN 'ORGANISATION' THEN 1 WHEN 'DELIVERY_POINT' THEN 2 WHEN 'CUSTOM_LEVEL' THEN 3 ELSE 4 END AS source_rank
             FROM normalized
         ),

--- a/ukam_os_builder/data_sources/abp/transform/stages/lpi.py
+++ b/ukam_os_builder/data_sources/abp/transform/stages/lpi.py
@@ -70,15 +70,15 @@ matching messy user input. We output variants based on **Logical Status**:
     locally known as "Rose Cottage").
 3.  **Provisional (6):** The address assigned during planning/construction, which
     might change before the house is built.
-
-Historic addresses (logical_status=8) are excluded from output.
+4.  **Historic (8):** An old address. If "10 High St" is renumbered to "12 High St",
+    the old address is kept as Historic. This helps match old datasets.
 
 ------------------------------------------------------------------------------
 Key Columns Explained
 ------------------------------------------------------------------------------
 *   `uprn`: The "Golden Key". Use this to link this address to other data.
 *   `base_address`: The constructed full address string.
-*   `logical_status`: 1=Current, 6=Provisional.
+*   `logical_status`: 1=Current, 6=Provisional, 8=Historic.
 *   `official_flag`: 'Y' indicates this is the "official" version, 'N' suggests
     it might be an unofficial alias.
 *   `language`: 'ENG' (English) or 'CYM' (Welsh). Streets in Wales often have
@@ -88,6 +88,15 @@ Key Columns Explained
 from __future__ import annotations
 
 import duckdb
+
+from ukam_os_builder.data_sources.abp.abp_exclusions import included_abp_logical_statuses
+
+
+def _status_list_sql(excluded_logical_statuses: list[int] | None = None) -> str:
+    statuses = included_abp_logical_statuses(excluded_logical_statuses)
+    if not statuses:
+        return "NULL"
+    return ", ".join(str(status) for status in statuses)
 
 
 def prepare_street_descriptor_views(
@@ -139,7 +148,10 @@ def prepare_street_descriptor_views(
     """)
 
 
-def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
+def prepare_lpi_base(
+    con: duckdb.DuckDBPyConnection,
+    excluded_logical_statuses: list[int] | None = None,
+) -> None:
     """Create materialised LPI base tables with address components.
 
     Note: This function requires that `parent_uprns_with_children` temp table
@@ -147,8 +159,10 @@ def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
     full BLPU dataset to correctly identify parent UPRNs even when their
     children are in different chunks.
     """
+    logical_statuses_sql = _status_list_sql(excluded_logical_statuses)
+
     con.execute("DROP TABLE IF EXISTS lpi_base_full")
-    con.execute("""
+    con.execute(f"""
         CREATE TEMPORARY TABLE lpi_base_full AS
         SELECT
             l.uprn,
@@ -183,6 +197,7 @@ def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
                 WHEN 1 THEN 0
                 WHEN 3 THEN 1
                 WHEN 6 THEN 2
+                WHEN 8 THEN 3
                 ELSE 9
             END AS status_rank
         FROM lpi l
@@ -191,7 +206,7 @@ def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
         LEFT JOIN _sd_best_by_lang sd_lang ON sd_lang.usrn = l.usrn AND sd_lang.language = l.language
         LEFT JOIN _sd_best_any sd_any ON sd_any.usrn = l.usrn
         WHERE (b.addressbase_postal != 'N' OR b.addressbase_postal IS NULL)
-          AND l.logical_status IN (1, 3, 6)
+          AND l.logical_status IN ({logical_statuses_sql})
     """)
 
     # Deduplicated distinct addresses
@@ -218,7 +233,7 @@ def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
 
     # Best current LPI per UPRN
     con.execute("DROP TABLE IF EXISTS lpi_best_current")
-    con.execute("""
+    con.execute(f"""
         CREATE TEMPORARY TABLE lpi_best_current AS
         SELECT *
         FROM (
@@ -239,7 +254,7 @@ def prepare_lpi_base(con: duckdb.DuckDBPyConnection) -> None:
                     ORDER BY status_rank, COALESCE(last_update_date, DATE '0001-01-01') DESC
                 ) AS rn
             FROM lpi_base_distinct
-            WHERE logical_status IN (1, 3, 6)
+            WHERE logical_status IN ({logical_statuses_sql})
         )
         WHERE rn = 1
     """)
@@ -265,6 +280,7 @@ def render_variants(con: duckdb.DuckDBPyConnection) -> None:
                 WHEN 1 THEN 'APPROVED'
                 WHEN 3 THEN 'ALTERNATIVE'
                 WHEN 6 THEN 'PROVISIONAL'
+                WHEN 8 THEN 'HISTORICAL'
             END AS variant_label,
             (logical_status = 1) AS is_primary
         FROM lpi_base_distinct

--- a/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
+++ b/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+NGD_ALTADD_EXCLUSION = "*_altadd"
+
+NGD_CORE_FILE_STEM_BY_EXCLUSION = {
+    "builtaddress": "add_gb_builtaddress",
+    "prebuildaddress": "add_gb_prebuildaddress",
+    "historicaddress": "add_gb_historicaddress",
+    "nonaddressableobject": "add_gb_nonaddressableobject",
+    "royalmailaddress": "add_gb_royalmailaddress",
+}
+
+VALID_NGD_EXCLUDED_STEMS = frozenset(
+    (*NGD_CORE_FILE_STEM_BY_EXCLUSION.keys(), NGD_ALTADD_EXCLUSION)
+)
+
+
+def format_valid_ngd_excluded_stems() -> str:
+    """Return valid NGD exclusion options for error messages and help text."""
+    return ", ".join((*NGD_CORE_FILE_STEM_BY_EXCLUSION.keys(), NGD_ALTADD_EXCLUSION))
+
+
+def normalise_ngd_excluded_stems(values: Iterable[Any] | None) -> list[str]:
+    """Validate and normalise NGD exclusion option names."""
+    if values is None:
+        return []
+
+    normalised: list[str] = []
+    seen: set[str] = set()
+    for raw_value in values:
+        if not isinstance(raw_value, str):
+            raise ValueError("ngd_excluded_stems entries must be strings")
+
+        value = raw_value.strip().lower()
+        if value not in VALID_NGD_EXCLUDED_STEMS:
+            raise ValueError(
+                "invalid NGD excluded stem "
+                f"{raw_value!r}; valid options are: {format_valid_ngd_excluded_stems()}"
+            )
+
+        if value not in seen:
+            normalised.append(value)
+            seen.add(value)
+
+    return normalised
+
+
+def parse_ngd_excluded_stems(value: str | Iterable[Any] | None) -> list[str]:
+    """Parse CLI/API exclusion input into validated option names."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        if not value.strip():
+            return []
+        return normalise_ngd_excluded_stems(part.strip() for part in value.split(","))
+    return normalise_ngd_excluded_stems(value)
+
+
+def get_configured_ngd_excluded_stems(settings: Any) -> list[str]:
+    """Read configured NGD exclusions from a settings-like object."""
+    processing = getattr(settings, "processing", None)
+    return normalise_ngd_excluded_stems(getattr(processing, "ngd_excluded_stems", []))
+
+
+def is_ngd_address_file(name: str) -> bool:
+    """Return True when a path name looks like an NGD address feature file."""
+    return Path(name).name.lower().startswith("add_gb_")
+
+
+def ngd_file_matches_excluded_stem(name: str, excluded_stems: Iterable[Any] | None) -> bool:
+    """Return True when an NGD file name matches configured exclusions.
+
+    Core feature options match exact file stems.
+    historicaddress matches add_gb_historicaddress but not add_gb_historicaddress_altadd
+    *_altadd option matches every NGD alternate-address file.
+    """
+    excluded = set(normalise_ngd_excluded_stems(excluded_stems))
+    if not excluded:
+        return False
+
+    file_stem = Path(name).stem.lower()
+    if NGD_ALTADD_EXCLUSION in excluded and file_stem.startswith("add_gb_"):
+        if file_stem.endswith("_altadd"):
+            return True
+
+    return any(
+        file_stem == ngd_file_stem
+        for excluded_stem, ngd_file_stem in NGD_CORE_FILE_STEM_BY_EXCLUSION.items()
+        if excluded_stem in excluded
+    )

--- a/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
+++ b/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
@@ -13,6 +13,7 @@ NGD_CORE_FILE_STEM_BY_EXCLUSION = {
 }
 
 VALID_NGD_EXCLUDED_STEMS = frozenset(NGD_CORE_FILE_STEM_BY_EXCLUSION)
+DEFAULT_NGD_EXCLUDED_STEMS = ("historicaddress",)
 
 
 def format_valid_ngd_excluded_stems() -> str:
@@ -59,7 +60,9 @@ def parse_ngd_excluded_stems(value: str | Iterable[Any] | None) -> list[str]:
 def get_configured_ngd_excluded_stems(settings: Any) -> list[str]:
     """Read configured NGD exclusions from a settings-like object."""
     processing = getattr(settings, "processing", None)
-    return normalise_ngd_excluded_stems(getattr(processing, "ngd_excluded_stems", []))
+    return normalise_ngd_excluded_stems(
+        getattr(processing, "ngd_excluded_stems", DEFAULT_NGD_EXCLUDED_STEMS)
+    )
 
 
 def is_ngd_address_file(name: str) -> bool:
@@ -67,7 +70,10 @@ def is_ngd_address_file(name: str) -> bool:
     return Path(name).name.lower().startswith("add_gb_")
 
 
-def ngd_file_matches_excluded_stem(name: str, excluded_stems: Iterable[Any] | None) -> bool:
+def ngd_file_matches_excluded_stem(
+    name: str,
+    excluded_stems: Iterable[Any] | None,
+) -> bool:
     """Return True when an NGD file name matches configured exclusions.
 
     Feature options match the core feature file and its alternate-address file,

--- a/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
+++ b/ukam_os_builder/data_sources/ngd/ngd_exclusions.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
-NGD_ALTADD_EXCLUSION = "*_altadd"
-
 NGD_CORE_FILE_STEM_BY_EXCLUSION = {
     "builtaddress": "add_gb_builtaddress",
     "prebuildaddress": "add_gb_prebuildaddress",
@@ -14,14 +12,12 @@ NGD_CORE_FILE_STEM_BY_EXCLUSION = {
     "royalmailaddress": "add_gb_royalmailaddress",
 }
 
-VALID_NGD_EXCLUDED_STEMS = frozenset(
-    (*NGD_CORE_FILE_STEM_BY_EXCLUSION.keys(), NGD_ALTADD_EXCLUSION)
-)
+VALID_NGD_EXCLUDED_STEMS = frozenset(NGD_CORE_FILE_STEM_BY_EXCLUSION)
 
 
 def format_valid_ngd_excluded_stems() -> str:
     """Return valid NGD exclusion options for error messages and help text."""
-    return ", ".join((*NGD_CORE_FILE_STEM_BY_EXCLUSION.keys(), NGD_ALTADD_EXCLUSION))
+    return ", ".join(NGD_CORE_FILE_STEM_BY_EXCLUSION)
 
 
 def normalise_ngd_excluded_stems(values: Iterable[Any] | None) -> list[str]:
@@ -74,21 +70,18 @@ def is_ngd_address_file(name: str) -> bool:
 def ngd_file_matches_excluded_stem(name: str, excluded_stems: Iterable[Any] | None) -> bool:
     """Return True when an NGD file name matches configured exclusions.
 
-    Core feature options match exact file stems.
-    historicaddress matches add_gb_historicaddress but not add_gb_historicaddress_altadd
-    *_altadd option matches every NGD alternate-address file.
+    Feature options match the core feature file and its alternate-address file,
+    so ``builtaddress`` matches both ``add_gb_builtaddress`` and
+    ``add_gb_builtaddress_altadd``.
     """
     excluded = set(normalise_ngd_excluded_stems(excluded_stems))
     if not excluded:
         return False
 
     file_stem = Path(name).stem.lower()
-    if NGD_ALTADD_EXCLUSION in excluded and file_stem.startswith("add_gb_"):
-        if file_stem.endswith("_altadd"):
-            return True
 
     return any(
-        file_stem == ngd_file_stem
+        file_stem in {ngd_file_stem, f"{ngd_file_stem}_altadd"}
         for excluded_stem, ngd_file_stem in NGD_CORE_FILE_STEM_BY_EXCLUSION.items()
         if excluded_stem in excluded
     )

--- a/ukam_os_builder/data_sources/ngd/to_flatfile.py
+++ b/ukam_os_builder/data_sources/ngd/to_flatfile.py
@@ -2,7 +2,7 @@
 
 Transforms the extracted parquet files into a single flatfile suitable for
 UK address matching. This includes:
-- Processing core feature types (Built Address, Pre-Build Address, etc.)
+- Processing core feature types (Built Address, Historic Address, etc.)
 - Processing alternate address records
 - Processing Royal Mail addresses
 - Handling Welsh language variants
@@ -19,6 +19,10 @@ import duckdb
 
 from ukam_os_builder._exceptions import ToFlatfileError
 from ukam_os_builder.api.settings import Settings, create_duckdb_connection
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    get_configured_ngd_excluded_stems,
+    ngd_file_matches_excluded_stem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,8 @@ logger = logging.getLogger(__name__)
 FEATURE_TYPE_BY_STEM = {
     "add_gb_builtaddress": "Built Address",
     "add_gb_builtaddress_altadd": "Built Address",
+    "add_gb_historicaddress": "Historic Address",
+    "add_gb_historicaddress_altadd": "Historic Address",
     "add_gb_nonaddressableobject": "Non-Addressable Object",
     "add_gb_nonaddressableobject_altadd": "Non-Addressable Object",
     "add_gb_prebuildaddress": "Pre-Build Address",
@@ -37,6 +43,7 @@ FEATURE_TYPE_BY_STEM = {
 # Core feature stems (contain fulladdress and classification fields)
 CORE_FEATURE_STEMS = {
     "add_gb_builtaddress",
+    "add_gb_historicaddress",
     "add_gb_nonaddressableobject",
     "add_gb_prebuildaddress",
 }
@@ -44,6 +51,7 @@ CORE_FEATURE_STEMS = {
 # Alternate address stems (no classification fields)
 ALTADD_STEMS = {
     "add_gb_builtaddress_altadd",
+    "add_gb_historicaddress_altadd",
     "add_gb_nonaddressableobject_altadd",
     "add_gb_prebuildaddress_altadd",
 }
@@ -53,6 +61,7 @@ CORE_FEATURE_PRIORITY = {
     "add_gb_builtaddress": 1,
     "add_gb_prebuildaddress": 2,
     "add_gb_nonaddressableobject": 3,
+    "add_gb_historicaddress": 4,
 }
 
 
@@ -66,7 +75,7 @@ def _create_metadata_lookup_view(
     This view is used to enrich Royal Mail and alternate address records
     with metadata (classificationcode, parentuprn, etc.) by UPRN lookup.
 
-    Uses priority ranking (Built > Pre-Build > Non-Addressable)
+    Uses priority ranking (Built > Pre-Build > Non-Addressable > Historic)
     to dedupe when a UPRN exists in multiple core files.
 
     Args:
@@ -143,6 +152,17 @@ def _create_metadata_lookup_view(
         con.execute(sql)
 
     built_path = parquet_dir / "add_gb_builtaddress.parquet"
+    if not built_path.exists():
+        logger.warning("Built Address file not found. LTLA lookup will be empty.")
+        con.execute("""
+            CREATE OR REPLACE TEMP VIEW builtaddress_ltla_lookup AS
+            SELECT
+                CAST(NULL AS BIGINT) AS uprn,
+                CAST(NULL AS VARCHAR) AS lowertierlocalauthoritygsscode
+            WHERE 1=0
+        """)
+        return
+
     built_sql = f"""
         CREATE OR REPLACE TEMP VIEW builtaddress_ltla_lookup AS
         SELECT
@@ -161,7 +181,7 @@ def _create_core_feature_view(
     parquet_path: Path,
     uprn_predicate: str | None = None,
 ) -> None:
-    """Create view for core feature types (Built, Pre-Build, Non-Addressable).
+    """Create view for core feature types (Built, Historic, Pre-Build, Non-Addressable).
 
     These tables have fulladdress, classification fields, and Welsh language columns.
     Produces both English and Welsh (where available) address records.
@@ -512,7 +532,7 @@ def _create_dedup_view(con: duckdb.DuckDBPyConnection) -> None:
     """Create deduplicated view of all addresses.
 
     Priority rules for deduplication:
-    - Feature type: Built Address -> Pre-Build -> Royal Mail -> Non-Addressable
+    - Feature type: Built Address -> Pre-Build -> Royal Mail -> Historic -> Non-Addressable
     - Address status: Approved -> Provisional -> Alternative -> Historical
     - Build status: Built Complete -> Under Construction -> Prebuild -> Historic -> Demolished
 
@@ -528,6 +548,7 @@ def _create_dedup_view(con: duckdb.DuckDBPyConnection) -> None:
               WHEN 'Built Address' THEN 1
               WHEN 'Pre-Build Address' THEN 2
               WHEN 'Royal Mail Address' THEN 3
+              WHEN 'Historic Address' THEN 4
               WHEN 'Non-Addressable Object' THEN 5
               WHEN 'Custom Level' THEN 6
               ELSE 9
@@ -648,6 +669,19 @@ def run_flatfile_step(settings: Settings, force: bool = False) -> list[Path]:
         )
 
     parquet_files = list(parquet_dir.glob("*.parquet"))
+    ngd_excluded_stems = get_configured_ngd_excluded_stems(settings)
+    if ngd_excluded_stems:
+        original_count = len(parquet_files)
+        parquet_files = [
+            path
+            for path in parquet_files
+            if not ngd_file_matches_excluded_stem(path.name, ngd_excluded_stems)
+        ]
+        if len(parquet_files) != original_count:
+            logger.info(
+                "Skipped %d excluded NGD parquet file(s)",
+                original_count - len(parquet_files),
+            )
     if not parquet_files:
         raise ToFlatfileError(f"No parquet files found in {parquet_dir}. Run --step extract first.")
 

--- a/ukam_os_builder/os_builder/extract.py
+++ b/ukam_os_builder/os_builder/extract.py
@@ -8,12 +8,13 @@ from pathlib import Path
 import duckdb
 
 from ukam_os_builder.api.settings import Settings
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    get_configured_ngd_excluded_stems,
+    is_ngd_address_file,
+    ngd_file_matches_excluded_stem,
+)
 
 logger = logging.getLogger(__name__)
-
-# NGD file stems to exclude (historic addresses are not used in output)
-_NGD_EXCLUDED_STEMS = {"historicaddress"}
-
 
 def find_downloaded_zips(downloads_dir: Path) -> list[Path]:
     """Find all downloaded zip files in a directory."""
@@ -25,22 +26,21 @@ def find_downloaded_zips(downloads_dir: Path) -> list[Path]:
     return zip_files
 
 
-def _is_excluded_ngd_file(name: str) -> bool:
-    """Return True if *name* matches an excluded NGD stem (e.g. historicaddress)."""
-    name_lower = name.lower()
-    return any(stem in name_lower for stem in _NGD_EXCLUDED_STEMS)
-
-
-def _filter_zips_for_source(zip_files: list[Path], source: str) -> list[Path]:
+def _filter_zips_for_source(
+    zip_files: list[Path],
+    source: str,
+    ngd_excluded_stems: list[str] | None = None,
+) -> list[Path]:
     source_lower = source.lower()
     if source_lower == "ngd":
-        ngd_zips = [
+        ngd_zips = [zip_path for zip_path in zip_files if is_ngd_address_file(zip_path.name)]
+        if not ngd_zips:
+            return zip_files
+        return [
             zip_path
-            for zip_path in zip_files
-            if zip_path.name.lower().startswith("add_gb_")
-            and not _is_excluded_ngd_file(zip_path.name)
+            for zip_path in ngd_zips
+            if not ngd_file_matches_excluded_stem(zip_path.name, ngd_excluded_stems)
         ]
-        return ngd_zips or zip_files
     if source_lower == "abp":
         abp_zips = [
             zip_path for zip_path in zip_files if "addressbasepremium" in zip_path.name.lower()
@@ -49,10 +49,16 @@ def _filter_zips_for_source(zip_files: list[Path], source: str) -> list[Path]:
     return zip_files
 
 
-def _should_convert_csv_to_parquet(csv_path: Path, source: str) -> bool:
+def _should_convert_csv_to_parquet(
+    csv_path: Path,
+    source: str,
+    ngd_excluded_stems: list[str] | None = None,
+) -> bool:
     if source.lower() == "ngd":
-        name_lower = csv_path.name.lower()
-        return name_lower.startswith("add_gb_") and not _is_excluded_ngd_file(name_lower)
+        return is_ngd_address_file(csv_path.name) and not ngd_file_matches_excluded_stem(
+            csv_path.name,
+            ngd_excluded_stems,
+        )
     return True
 
 
@@ -218,7 +224,8 @@ def run_extract_step(
         return []
 
     source_type = settings.source.type
-    filtered_zip_files = _filter_zips_for_source(zip_files, source_type)
+    ngd_excluded_stems = get_configured_ngd_excluded_stems(settings)
+    filtered_zip_files = _filter_zips_for_source(zip_files, source_type, ngd_excluded_stems)
     if len(filtered_zip_files) != len(zip_files):
         logger.info(
             "Filtered %d zip file(s) for source '%s' (from %d total)",
@@ -241,7 +248,11 @@ def run_extract_step(
             # Convert each CSV to parquet
             parquet_dir = extracted_dir / "parquet"
             for csv_path in csv_paths:
-                if not _should_convert_csv_to_parquet(csv_path, source_type):
+                if not _should_convert_csv_to_parquet(
+                    csv_path,
+                    source_type,
+                    ngd_excluded_stems,
+                ):
                     logger.debug(
                         "Skipping CSV-to-parquet for source '%s': %s", source_type, csv_path
                     )

--- a/ukam_os_builder/os_builder/os_hub.py
+++ b/ukam_os_builder/os_builder/os_hub.py
@@ -10,22 +10,24 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 import requests
 
 from ukam_os_builder.api.settings import Settings
+from ukam_os_builder.data_sources.ngd.ngd_exclusions import (
+    get_configured_ngd_excluded_stems,
+    ngd_file_matches_excluded_stem,
+)
 
 logger = logging.getLogger(__name__)
 
 API_BASE_URL = "https://api.os.uk/downloads/v1"
 
-# NGD file stems to exclude (historic addresses are not used in output)
-_NGD_EXCLUDED_STEMS = {"historicaddress"}
-
-
 def _should_skip_ngd_download(filename: str, settings: object) -> bool:
-    """Return True if *filename* is an NGD historic-address archive."""
+    """Return True if *filename* matches configured NGD feature exclusions."""
     source_type = getattr(getattr(settings, "source", None), "type", "")
     if source_type != "ngd":
         return False
-    name_lower = filename.lower()
-    return any(stem in name_lower for stem in _NGD_EXCLUDED_STEMS)
+    return ngd_file_matches_excluded_stem(
+        filename,
+        get_configured_ngd_excluded_stems(settings),
+    )
 
 
 DEFAULT_CHUNK_SIZE = 1024 * 1024 * 20  # 20 MiB
@@ -333,9 +335,8 @@ def run_download_step(
                 logger.warning("No URL for %s, skipping", item.filename)
                 continue
 
-            # Skip NGD historic address files — they are excluded from output
             if _should_skip_ngd_download(item.filename, settings):
-                logger.info("Skipping historic address file: %s", item.filename)
+                logger.info("Skipping excluded NGD file: %s", item.filename)
                 continue
 
             dest_path = downloads_dir / item.filename


### PR DESCRIPTION
Replace the hard coded exclusion of historic address records with configurable exclusion options for both NGD and ABP processing.
	
The [linked commit](https://github.com/moj-analytical-services/ukam_os_builder/commit/c4fa6e1e8db97c070bfc908132be8b3448f9315a), removed historic address processing by:
- Skipping NGD historic files during download and extract
- Removing NGD historic stems from flatfile processing
- Removing add_gb_historicaddress.csv from smoke test coverage
- Excluding ABP LPI records with logical_status=8
- Removing ABP historic status ranking and HISTORICAL variant labelling
	
The intent of this PR is to add back in historic addresses and allow exclusions to be configurable instead. By default, no NGD feature types and no ABP logical statuses are excluded.


Changes:

- Adds processing.ngd_excluded_stems, defaulting to []
- Adds processing.abp_excluded_logical_statuses, defaulting to []
- Restores NGD historic support 
- Restores ABP historic LPI support
- Replaces hard-coded NGD historic download/extract skips with configurable filtering
- Added Python API support via create_config_and_env(...) and CLI overrides for --ngd-excluded-stems and --abp-excluded-logical-statuses
- Updated README, example config, and tests

Testing:
Added tests for NGD configurable feature exclusions
Added tests for ABP logical status exclusions
Added config/API/CLI validation coverage