### PR TITLE
Add ABP local custodian code to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Each file contains:
 | `postal_address_code` | Postal address indicator |
 | `udprn` | Royal Mail delivery point reference |
 | `parent_uprn` | Parent UPRN for hierarchical addresses |
+| `local_custodian_code` | [Local Authority custodian code](https://docs.os.uk/os-downloads/products/addresses-and-names-portfolio/addressbase-fundamentals/addressbase-local-custodian-codes) identifying the authority responsible for maintaining the address record |
 | `hierarchy_level` | C = Child, P = Parent, S = Singleton |
 | `source` | Data source (LPI, ORGANISATION, DELIVERY_POINT, CUSTOM_LEVEL) |
 | `variant_label` | Address variant type |

--- a/tests/test_abp_output.py
+++ b/tests/test_abp_output.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import duckdb
+
+from ukam_os_builder.data_sources.abp.transform.stages.combine import (
+    combine_and_dedupe,
+)
+
+
+def test_abp_output_includes_local_custodian_code() -> None:
+    con = duckdb.connect()
+    con.execute("""
+        CREATE TABLE _stage_lpi_variants AS
+        SELECT
+            100000000001::BIGINT AS uprn,
+            'E8 1EA'::VARCHAR AS postcode,
+            '1 TEST STREET'::VARCHAR AS raw_address,
+            'LPI'::VARCHAR AS source,
+            1::INTEGER AS logical_status,
+            '2'::VARCHAR AS blpu_state,
+            'D'::VARCHAR AS postal_address_code,
+            NULL::BIGINT AS parent_uprn,
+            'S'::VARCHAR AS hierarchy_level,
+            'PRIMARY'::VARCHAR AS variant_label,
+            TRUE AS is_primary
+    """)
+    for table_name in (
+        "_stage_business_variants",
+        "_stage_delivery_point_variants",
+        "_stage_custom_level_variants",
+    ):
+        con.execute(
+            f"CREATE TABLE {table_name} AS "
+            "SELECT * FROM _stage_lpi_variants WHERE FALSE"
+        )
+
+    con.execute("""
+        CREATE TABLE classification_best (
+            uprn BIGINT,
+            classification_code VARCHAR
+        );
+        CREATE TABLE delivery_point_best (
+            uprn BIGINT,
+            udprn BIGINT
+        );
+        CREATE TABLE blpu (
+            uprn BIGINT,
+            local_custodian_code INTEGER
+        );
+        INSERT INTO blpu VALUES (100000000001, 5360);
+    """)
+
+    result = combine_and_dedupe(con)
+
+    assert result.project("unique_id, local_custodian_code").fetchone() == (
+        100000000001,
+        5360,
+    )
+    con.close()

--- a/ukam_os_builder/data_sources/abp/transform/stages/combine.py
+++ b/ukam_os_builder/data_sources/abp/transform/stages/combine.py
@@ -71,6 +71,7 @@ def combine_and_dedupe(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyRelatio
             sr.postal_address_code,
             dp.udprn,
             sr.parent_uprn,
+            b.local_custodian_code,
             sr.hierarchy_level,
             sr.source,
             sr.variant_label,
@@ -78,4 +79,5 @@ def combine_and_dedupe(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyRelatio
         FROM source_ranked sr
         LEFT JOIN classification_best cb ON cb.uprn = sr.uprn
         LEFT JOIN delivery_point_best dp ON dp.uprn = sr.uprn
+        LEFT JOIN blpu b ON b.uprn = sr.uprn
     """)


### PR DESCRIPTION
## Summary

Adds `local_custodian_code` to the AddressBase Premium output, sourced from the BLPU record by UPRN. This enables `uk_address_matcher` users to filter canonical addresses by the local authority responsible for maintaining each address record.

For example, addresses maintained by Hackney (custodian code `5360`) can be restricted to residential classifications:
```
matcher = AddressMatcher(
    canonical_addresses=str(canonical_prepared_path),
    canonical_address_filter=(
        "local_custodian_code = 5360 "
        "and substr(classification_code, 1, 1) = 'R'"
    ),
    addresses_to_match=df_messy,
    con=con,
    stages=[
        ExactMatchStage(),
        SplinkStage(
            final_distinguishability_threshold=1.0,
        ),
    ],
)
```
Also adds regression coverage and edited the README to include the `local_custodian_code` with a link to the [[OS local custodian code lookup](https://docs.os.uk/os-downloads/products/addresses-and-names-portfolio/addressbase-fundamentals/addressbase-local-custodian-codes)](https://docs.os.uk/os-downloads/products/addresses-and-names-portfolio/addressbase-fundamentals/addressbase-local-custodian-codes).

## Testing

* 60 tests passed
* Ruff checks passed

The test might not be needed.

## NGD Comparison

In addition, in the Hackney test in `uk_address_matcher`, you use `lowertierlocalauthoritygsscode = 'E09000012'`, and ukam_os_builder doesn't currently pull `local_custodian_code` from NGD data. 

My understanding of the difference is:

| Field | Meaning |
| --- | --- |
| lowertierlocalauthoritygsscode | Authority area in which the address is located, most likely using a geographic-boundary identifier |
| localcustodiancode | Authority responsible for assigning/maintaining the UPRN record |

And as in the tests you're using the data maintained by Hackney Council, it may be better to filter via `local_custodian_code` in NGD/ABP. Might be worth doing a comparison. But in my PR I haven't added `local_custodian_code` for NGD data. Might be worth adding to NGD output.

I can edit the PR to include `local_custodian_code` in NGD output if needed, but might be worth contacting Ordnance Survey to understand the real difference.